### PR TITLE
Removal of links to mardown.css and rst.css

### DIFF
--- a/web/cm/codemirror.plug.js
+++ b/web/cm/codemirror.plug.js
@@ -55,7 +55,7 @@ var importCodeMirrorMode = ( function() {
     }
     if ( mode = mimes[mime] ) {
 
-      if ( mode === 'diff' || mode === 'tiddlywiki' || mode === 'markdown' || mode === 'rst' ) {
+      if ( mode === 'diff' || mode === 'tiddlywiki' ) {
         var link = document.createElement('link');
         link.rel = "stylesheet";
         link.href = "/cm/mode/" + mode + "/" + mode + ".css";


### PR DESCRIPTION
Following the removal of those css files in CodeMirror2, we have to remove all links to them.
