### PR TITLE
[Makefile] Better auto init

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ clean:
 init: clean web/ node_modules/bcrypt/
 
 web/:
-	@git clone git@github.com:garden/plugs web
+	@git clone http://github.com/garden/plugs web
 
 node_modules/bcrypt/:
 	@npm install bcrypt


### PR DESCRIPTION
This gets rid of the need to `make init` before `make` can work. For the future, we should let npm manage our dependencies (for more simplicity and windows-compatibility).
