### PR TITLE
Broken "cat" function

### DIFF
--- a/app.js
+++ b/app.js
@@ -90,7 +90,7 @@ camp.ajax.on('fs', function (query, end) {
         if (err) { data.err = err; end(data); }
         data.type = file.type;  // eg, 'text/html'
         data.name = nodepath.basename(query.path);
-        file.open (function (err) {
+        file.open (function (err, content) {
           if (err) { data.err = err; end(data); }
           data.content = content;
           end(data);

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -204,7 +204,7 @@ File.prototype.open = function (cb) {
           that.writo = setInterval(writeAtPeriod.bind(that), File.writePeriod);
         }
       }
-      cb(err);
+      cb(err, data);
     });
   } else {
     // Counts.


### PR DESCRIPTION
Hey guys,

I tried to call the "cat" function of the file tree's file system with curl :

```
pathToFile="/test/"
fileName="tester2"
curl -s -d "op=%22cat%22&path=%22$pathToFile$fileName%22" localhost/\$fs
```

And this was stopping the file tree with this king of error :

```
/home/tpatel/garden/tree/app.js:95
          data.content = content;
                         ^
ReferenceError: content is not defined
    at /home/tpatel/garden/tree/app.js:95:26
    at /home/tpatel/garden/tree/lib/fs.js:207:7
    at [object Object].<anonymous> (fs.js:123:5)
    at [object Object].emit (events.js:64:17)
    at Object.oncomplete (fs.js:1190:12)
```

So I'm proposing a fix to avoir this error : getting the content of the file from the driver.open function, by adding parameters in the callback.

However, this fix introduces a new problem : when you try to _cat_ a file a long time after having opened it, the "content" attribute is null, that is to say it is not sent back to the user.
