### PR TITLE
Driver: Fixed EMFILE caused because the number of processes spawning can become overwhelming for the operating system after some point, which occurs when loading metadata.

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -82,19 +82,26 @@ function dumpMeta (vpath, data, cb) {
 
     // First, we need to create all directories down to the meta file
     // (excluding the file, that is).
-    child.spawn('mkdir', ['-p',path.dirname(file)]).on('exit', function (code) {
-      if (code !== 0) {
-        console.error('Error: dumping metadata ended with code ' + code +
-                      ' with directory', path.dirname(file));
-        return;
-      }
+    var createDirs;
+    try {
+      createDirs = child.spawn('mkdir', ['-p',path.dirname(file)]);
+      createDirs.on('exit', function (code) {
+        if (code !== 0) {
+          console.error('Error: dumping metadata ended with code ' + code +
+                        ' with directory', path.dirname(file));
+          return;
+        }
 
-      // Then, we want to dump the metadata as JSON in that file.
-      nodefs.writeFile(file, JSON.stringify(data), function (err) {
-        if (err) console.error('While dumping metadata:', err.stack);
-        cb(err);
+        // Then, we want to dump the metadata as JSON in that file.
+        nodefs.writeFile(file, JSON.stringify(data), function (err) {
+          if (err) console.error('While dumping metadata:', err.stack);
+          cb(err);
+        });
       });
-    });
+    } catch (e) {
+      cb(e);
+      return;
+    }
   });
 }
 


### PR DESCRIPTION
A try / catch makes sure the server doesn't crash in the process, and we alert the caller of this method of the error we got.
