### PR TITLE
Fixed broken "cat" function

### DIFF
--- a/app.js
+++ b/app.js
@@ -87,12 +87,12 @@ camp.ajax.on('fs', function (query, end) {
       break;
     case 'cat':
       fs.file(query.path, function (err, file) {
-        if (err) { data.err = err; return end(data); }
+        if (err) { data.err = err; end(data); return; }
         data.meta = file.meta;
         data.path = query.path;
         file.open (function (err, content) {
           if (err) { data.err = err; end(data); }
-          data.content = (content == null ? file.content : content);
+          data.content = file.content;
           end(data);
         });
       });

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -114,7 +114,7 @@ function file (vpath, cb) {
   type.guessType(that.path, function (err, td) {
     if (err) {
       //console.error("While guessing type of", that.path, err.stack);
-      fileFromPath[path] = undefined;
+      delete fileFromPath[path];
       cb(err);
       return;
     }


### PR DESCRIPTION
This time the "cat" function respond with a "content" attribute all the time.

The curl I used to test the fix :
`curl -s -d "op=%22cat%22&path=%22/test/testFile%22" localhost/\$fs`
