### PR TITLE
support v0.8.0, ditch broken socket.io client gzip

### DIFF
--- a/app.js
+++ b/app.js
@@ -29,7 +29,7 @@ var Camp = require('camp'),
 camp.io.configure('development', function () {
   camp.io.set('log level', 0);
   camp.io.set('browser client minification', true);
-  camp.io.set('browser client gzip', true);
+//  camp.io.set('browser client gzip', true); // FIXME broken since v0.8.0
 });
 
 Camp.Plate.parsers['script'] = function (text) {


### PR DESCRIPTION
I knew that socket.io was going to be a problem for staying bleeding edge. We should seriously look into removing it, we already have all the technology in camp.
