### PR TITLE
Add HTTP header Last-Modified

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -1,4 +1,4 @@
-/* driver.js: Primitives to deal with the way we store data on disk.
+/* Primitives to deal with the way we store data on disk.
  * Copyright © 2011 Jan Keromnes, Thaddee Tyl. All rights reserved.
  * The following code is covered by the GPLv2 license. */
 

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -97,6 +97,8 @@ function File (path) {
   this.type = null;
   this.meta = {};   // Default: empty (may be overriden by what is on disk).
 
+  this.date = new Date(); // Time when last modified
+
   this.writo = null;    // Regular write timeout.
   this.nbops = 0;       // Number of operations since last period.
 }
@@ -143,6 +145,17 @@ function file (vpath, cb) {
 }
 
 
+// Change `file.updated` to current timestamp when callback is called.
+//
+// - `cb`: a function
+//
+File.prototype.wrapUpdate = function (cb) {
+  var that = this;
+  return function () {
+    that.date = new Date();
+    cb.apply({}, arguments);
+  };
+}
 
 // Checks whether a `file` is of type `typename` (or falls back into it).
 //
@@ -242,8 +255,9 @@ File.prototype.close = function () {
 };
 
 File.prototype.write = function (cb) {
-  if (this.content !== null && this.driver.write)
+  if (this.content !== null && this.driver.write) {
     this.driver.write(this.path, this.content, this.meta, cb);
+  }
 };
 
 File.prototype.writeMeta = function (cb) {
@@ -278,6 +292,7 @@ File.prototype.ot = function (io, cb) {
         socket.on('operation', function () {
           file.nbops++;
           file.content = channel.codeMirrorServer.str;
+          file.date = new Date();
           bench.latestFile = file.path;
         });
       });
@@ -322,9 +337,9 @@ File.prototype.mkdir = function (name, cb) {
   if (this.isOfType('dir')) {
     // We don't want name to have slashes (avoid attacks).
     if (name.indexOf('/') !== -1) {
-      console.error("fs:file:mkdir: made folder %s which has a /.", name);
+      console.error("fs:file:mkdir: cannot make folder %s which has a /.", name);
     } else {
-      this.driver.mkdir(this.path + '/' + name + '/', cb);
+      this.driver.mkdir(this.path + '/' + name + '/', this.wrapUpdate(cb));
     }
   } else {
     console.error("fs:file:mkdir: tried to make folder %s from non-folder %s.",
@@ -336,9 +351,9 @@ File.prototype.mkfile = function (name, cb) {
   if (this.driver.mkfile) {
     // We don't want name to have slashes (avoid attacks).
     if (name.indexOf('/') !== -1) {
-      console.error("fs:file:mkdir: made folder %s which has a /.", name);
+      console.error("fs:file:mkdir: cannot make folder %s which has a /.", name);
     } else {
-      this.driver.mkfile(this.path + '/' + name, cb);
+      this.driver.mkfile(this.path + '/' + name, this.wrapUpdate(cb));
     }
   } else {
     console.error("fs:file:mkfile: tried to make file %s from non-folder %s.",

--- a/lib/plug.js
+++ b/lib/plug.js
@@ -57,6 +57,9 @@ exports.resolve = function (query, path, endres, ask) {
 
     // TODO If file requires a password and nothing matches, abort!
 
+    // set HTTP header Last-Modified
+    if (file.date)
+      ask.res.setHeader('Last-Modified', file.date.toGMTString());
 
     // PLUG MECHANISM
 


### PR DESCRIPTION
In FS, file dates are touched on:
- creation of File object
- operations (on a file)
- mkdir / mkfile (in a folder)

However, FS::File objects are created very often, I'm not sure why. I added a console log whenever a File object is created, look at the logs when you browse and open files in your browser, you might be surprised. This causes, among other things, the Last-Modified field to reset to current time when you open or close a file, even if there was no modification.
