### PR TITLE
[fsapi] fix `nodepath` is not defined

### DIFF
--- a/lib/fsapi.js
+++ b/lib/fsapi.js
@@ -2,7 +2,8 @@
  * Copyright © 2011 Jan Keromnes, Thaddee Tyl. All rights reserved.
  * The following code is covered by the GPLv2 license. */
 
-var fs = require('./fs');
+var fs = require('./fs'),
+    path = require('path');
 
 exports.fs = function fsOperation(query, end) {
   // `query` must have an `op` field, which is a String.
@@ -60,7 +61,7 @@ exports.fs = function fsOperation(query, end) {
         (query.type === "folder"? file.mkdir: file.mkfile).bind(file)
           (query.name, function (err) {
             data.err = err;
-            data.path = nodepath.join(query.path, query.name);
+            data.path = path.join(query.path, query.name);
             end(data);
         });
       });


### PR DESCRIPTION
how did we let this happen?
