### PR TITLE
A way to have a configurable plug=none on directories

### DIFF
--- a/lib/plug.js
+++ b/lib/plug.js
@@ -33,7 +33,7 @@ exports.resolve = function (query, path, endres, ask) {
         endres();
         return;
       }
-      if (!plug || plug === 'none')
+      if (!plug)
         sendraw();
       else {
         if (nodepath.extname(plug).length === 0) plug += '.html';
@@ -133,11 +133,6 @@ exports.resolve = function (query, path, endres, ask) {
     // Find a plug to use.
     var plug = data.lookup('plug');
 
-    if (plug === 'none') {
-      end(); // no plug
-      return;
-    }
-
     if (file.isOfType('dir')) {
 
       // Delay callback, wait for subfiles.
@@ -164,6 +159,10 @@ exports.resolve = function (query, path, endres, ask) {
         end(err, plug, data);
       });
 
+    } else if (plug === 'none') {
+      plug = false;
+      end(); // no plug
+      return;
     } else if (file.isOfType('text/plain')) {
 
       // Delay callback, wait for file content.


### PR DESCRIPTION
Just changed the plug=none on directories to use the template "none.html" to display the directory.
I think the "hack" to serve the files in a static way is ok, while we need to be able to configure the "plug=none" option on directories, using the template system.
I submitted a push request for a simple directory listing : garden/plugs#18
