### PR TITLE
[API] remove deprecated `ls` operation

### DIFF
--- a/lib/fsapi.js
+++ b/lib/fsapi.js
@@ -104,7 +104,7 @@ function fsOperation(query, end) {
   }
   var data = {};
   switch (query.op) {
-    case 'read': case 'cat': // case 'ls':
+    case 'read': case 'cat': case 'ls':
       read(query.path, query.depth || 0, end);
       break;
     case 'create': case 'new':
@@ -112,35 +112,6 @@ function fsOperation(query, end) {
       break;
     case 'delete': case 'rm':
       rm(query.path, end);
-      break;
-    // FIXME `ls` is deprecated, use `read` instead.
-    case 'ls':
-      fs.file(query.path, function (err, dir) {
-        if (err) {
-          data.err = err;
-          return end(data);
-        }
-        // ls -r
-        if (query.depth && query.depth > 1) {
-          dir.subfiles(function (err, subfiles) {
-            data.leafs = subfiles;
-            end(data);
-          }, query.depth);
-        // ls .
-        } else {
-          dir.files(function (err, files) {
-            if (err) { data.err = err; end(data); return; }
-            data.files = [];
-            for (var i = 0; i < files.length; i++) {
-              data.files.push({
-                name: files[i],
-                type: fs.type.nameFromType[files[i].type]
-              });
-            }
-            end(data);
-          });
-        }
-      });
       break;
     default:
       end({err: 'Unknown file system operation ' + query.op + '.'});


### PR DESCRIPTION
We don't use it in our code anymore. Time to clean up.
