### PR TITLE
OT: Unnecessary closing of file in the file system.

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -290,7 +290,6 @@ File.prototype.ot = function (io, cb) {
 
       cb(null);
     } else {
-      file.close();
       cb(null);
     }
   });


### PR DESCRIPTION
Plugs using both `{{=file.content}}` and OT have a bug wherein the nth time,
n > 1, that they are run, `file.content` would yield `null`.
This change fixes that bug.
