### PR TITLE
Plug: plug=none on a directory.

### DIFF
--- a/lib/plug.js
+++ b/lib/plug.js
@@ -22,10 +22,14 @@ exports.resolve = function (query, path, endres, ask) {
   path[1] = path[1];
   fs.file (path[1], function (err, file) {
 
-    function sendraw() {
-      console.log('send', path[1]);
-      path[0] = path[1];
-      endres(); // bypass template engine
+    function sendraw(data) {
+      if (data && data.content) {
+        ask.res.end(data.content);
+      } else {
+        console.log('send', path[1]);
+        path[0] = path[1];
+        endres(); // bypass template engine
+      }
     }
 
     function end(err, plug, data) {
@@ -36,7 +40,7 @@ exports.resolve = function (query, path, endres, ask) {
         return;
       }
       if (!plug || plug === 'none')
-        sendraw();
+        sendraw(data);
       else {
         if (nodepath.extname(plug).length === 0) plug += '.html';
         fs.file(plug, function(err, file) {
@@ -104,11 +108,6 @@ exports.resolve = function (query, path, endres, ask) {
 function findPlug(file, path, data, end) {
   var plug = data.lookup('plug');
 
-  if (plug === 'none') {
-    end(); // no plug
-    return;
-  }
-
   if (file.isOfType('dir')) {
 
     // Handle missing final '/'.
@@ -129,7 +128,14 @@ function findPlug(file, path, data, end) {
       }
       ///console.log('server:root: data sent from dir is', data);
 
-      if (plug == null) {
+      if (plug === 'none') {
+        // We must send a newline-separated list of subfile names.
+        var nameFromFile = function(f) {
+          return nodepath.basename(f.path);
+        };
+        var subfileNames = files.map(nameFromFile).join('\n');
+        end(err, null, {content: subfileNames});
+      } else if (plug == null) {
         data.lookup('plugs.dir', function(plug) {
           end(err, plug || 'gateway.html', data);
         });
@@ -137,6 +143,10 @@ function findPlug(file, path, data, end) {
         end(err, plug, data);
       }
     });
+
+  } else if (plug === 'none') {
+    end(); // no plug
+    return;
 
   } else if (file.isOfType('text')) {
 


### PR DESCRIPTION
Fixes #134 and #147.

It implements the behaviour specified in #147.
Requesting a directory with no plugs returns a newline-separated list of entry
names.
