### PR TITLE
Fixed crash on access to inexistant file.

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -126,6 +126,7 @@ primitives['dir'] = {
   read: function(vpath, cb) {fs.readdir(absolute(vpath), cb);},
   mkfile: function(vpath, cb) {fs.writeFile(absolute(vpath), '', cb);},
   mkdir: function(vpath, cb) {fs.mkdir(absolute(vpath), cb);},
+  stat: function(vpath, cb) {fs.stat(absolute(vpath), cb);},
   import: function(tmpfile, vpath, cb) {
     var source = temporary(tmpfile), destination = absolute(vpath);
     //console.log('importing', source, 'as', destination);
@@ -156,6 +157,7 @@ primitives['binary'] = {
     fs.writeFile(absolute(vpath), content, cb);
     dumpMeta(vpath, metadata);
   },
+  stat: primitives['dir'].stat,
   rm: function(vpath, cb) {
     metafile(normalize(vpath), function (err, fmeta) {
       if (err) {
@@ -174,6 +176,7 @@ primitives['text'] = {
     fs.writeFile(absolute(vpath), content, 'utf8', cb);
     dumpMeta(vpath, metadata);
   },
+  stat: primitives['dir'].stat,
   rm: primitives['binary'].rm
 };
 

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -142,7 +142,11 @@ function resetType(file, cb) {
         file.touch();
         file.writeMeta();
       }
-      cb(null, file);
+      if (file.meta['Content-Length'] === undefined) {
+        file.updateLength(cb);
+      } else {
+        cb(null, file);
+      }
     });
   });
 }
@@ -299,6 +303,20 @@ File.prototype.writeMeta = function (cb) {
   driver.dumpMeta(this.path, this.meta, function() { resetType(file, cb); });
 };
 
+File.prototype.updateLength = function(cb) {
+  var that = this;
+  this.driver.stat(that.path, function(err, stats) {
+    if (err) {
+      console.err('fs:updateLength error :', err.message);
+      if (cb) cb(err, that);
+    } else {
+      that.meta['Content-Length'] = stats.size;
+      that.writeMeta();
+      if (cb) cb(null, that);
+    }
+  });
+};
+
 File.prototype.touch = function () {
   this.meta['Last-Modified'] = Date.now();
 };
@@ -333,6 +351,7 @@ File.prototype.ot = function (io, cb) {
           file.nbops++;
           file.content = channel.codeMirrorServer.document;
           file.touch();
+          file.meta['Content-Length'] = content.length;
           bench.latestFile = file.path;
         });
       });
@@ -380,7 +399,10 @@ File.prototype.mkdir = function (name, cb) {
     } else {
       var self = this;
       this.driver.mkdir(nodepath.join(this.path, name), function (err) {
-        if (!err) { self.touch(); }
+        if (!err) {
+          self.touch();
+          self.updateLength();
+        }
         cb(err);
       });
     }
@@ -398,7 +420,10 @@ File.prototype.mkfile = function (name, cb) {
     } else {
       var self = this;
       this.driver.mkfile(nodepath.join(this.path, name), function (err) {
-        if (!err) { self.touch(); }
+        if (!err) {
+          self.touch();
+          self.meta['Content-Length'] = 0;
+        }
         cb(err);
       });
     }
@@ -416,7 +441,10 @@ File.prototype.import = function(tmpname, name, cb) {
     } else {
       var self = this;
       this.driver.import(tmpname, this.path + '/' + name, function (err) {
-        if (!err) { self.touch(); }
+        if (!err) {
+          self.touch();
+          self.updateLength();
+        }
         cb(err);
       });
     }


### PR DESCRIPTION
I believe espadrine forgot to update this bit on commit 35f5cc4ee3fe6f099477d19d5acee8b30dacb20e. It caused the tree to crash when someone tries to access an nonexistent file.
