### PR TITLE
fs: open(cb) automatically closes.

### DIFF
--- a/lib/README.md
+++ b/lib/README.md
@@ -47,10 +47,8 @@ File objects contain the following functions:
 * `this.content :: Object` lets you obtain the contents of the file.
   The content may be `null` (in order not to waste precious memory) unless you
   have opened the file.
-* `this.open :: Function ( cb :: Function (err) )`: use it when a user starts
-  editing a file.
-* `this.close :: Function ()`: use it when a user stops editing a file.
-  This function is useful to decide when to write to disk (non-blocking).
+* `this.open :: Function ( cb :: Function (err) )`: populate `this.content`, to
+  manipulate the file's content synchronously.
 * `this.write :: Function (cb)`: if you want to write the file to disk.
 * `this.writeMeta :: Function (cb)`: if you want to write metadata to disk.
 * `this.subfiles :: Function (cb :: Function(err, subfiles))`: gives all the

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -80,9 +80,7 @@ function profile (param) {
 // - `f.type` holds a number. See lib/type.js.
 // - `f.isOfType` is a method that takes a mime type (as a String).
 //   Open the file before using it. Close it when you stop accessing it.
-// - `f.open` will count one more user editing that file.
-// - `f.close` will count one less user. (That doesn't really matter
-//   for folders.)
+// - `f.open` will populate `f.content`.
 // - `f.rm` will remove the file for good (if nobody is using it).
 // - `f.driver` contains additional functionality associated to files of this
 //   type.
@@ -113,6 +111,13 @@ function file(vpath, cb) {
 
   var that = fileFromPath[path] = new File(path);
   resetType(that, cb);
+}
+
+function fopen(vpath, cb) {
+  file(vpath, function(err, f) {
+    if (err != null) { return cb(err); }
+    f.open(function(err) { cb(err, f); });
+  });
 }
 
 function resetType(file, cb) {
@@ -232,76 +237,57 @@ function writeAtPeriod() {
   this.nbops = 0;
 }
 
-function fopen(vpath, cb) {
-  file(vpath, function(err, f) {
-    if (err != null) { return cb(err); }
-    f.open(function(err) { cb(err, f); f.close(); });
-  });
-}
-
 // When you open a file, its content becomes synchronous, immediately available.
 // Use it when you need to use readSync and writeSync.
 File.prototype.open = function (cb) {
   //console.log('opening file', this.path);
+  this.count++;
+  bench.count[this.path]++;
+  var self = this;
+  // Decrease the counter upon calling cb.
+  var callcb = function(err, data) {
+    // content should be set.
+    cb(err, data);
+    self.count--;
+    bench.count[self.path]--;
+    if (self.count <= 0) {
+      // Write file content to disk before closing.
+      clearInterval(self.writo);
+      bench.openFiles--;
+      if (self.driver != null && self.driver.write != null) {
+        self.write(function(err) {
+          if (err) { console.error('fs:open: writing while closing', err.message); }
+          self.content = null;  // Let it be garbage-collected.
+        });
+      } else { self.content = null; }
+    }
+  };
   // If this file had no user, populate the content.
-  if (this.count <= 0) {
-    var that = this;
+  if (this.content == null) {
     if (this.driver == null) {
-      cb(new Error('Driverless file ' + that.path));
+      callcb(new Error('Driverless file ' + self.path));
       return;
     }
     this.driver.read(this.path, function(err, data) {
       if (err !== null) {
         console.error('fs:open:', err.message);
       } else {
-        that.content = data;
+        self.content = data;
         // Strings are UCS-2 (or UTF-16): characters are 2 bytes.
-        if (data.length)  bench.size += that.content.length * 2;
+        if (data.length) { bench.size += self.content.length * 2; }
 
         // Counts.
-        that.count++;
         bench.openFiles++;
         bench.totalOpenFilesEver++;
-        bench.count[that.path] = 1;
 
-        if (that.driver.write) {
-          that.writo = setInterval(writeAtPeriod.bind(that), File.writePeriod);
+        if (self.driver.write) {
+          self.writo = setInterval(writeAtPeriod.bind(self), File.writePeriod);
         }
       }
-      cb(err, data);
+      callcb(err, data);
     });
   } else {
-    // Counts.
-    this.count++;
-    bench.openFiles++;
-    bench.totalOpenFilesEver++;
-    bench.count[this.path]++;
-    cb(null);
-  }
-};
-
-File.prototype.close = function () {
-  //console.log('closing file', this.path);
-  if (this.count <= 0) {
-    console.error('fs:file: %s count is negative (%s). Keeping it at 0.',
-        this.path, this.count);
-  } else {
-    this.count--;
-    bench.openFiles--;
-    bench.count[this.path]--;
-  }
-
-  if (this.count === 0) {
-    var self = this;
-    if (this.driver == null) { return; }
-    if (this.driver.write) {
-      clearInterval(this.writo);
-      this.write(function (err) {
-        if (err) console.error('fs:write:', err.message);
-        self.content = null;    // Let it be garbage-collected.
-      });
-    } else this.content = null;
-    if (this.path !== '/') delete fileFromPath[this.path];
+    callcb(null);
   }
 };
 
@@ -326,7 +312,7 @@ File.prototype.ot = function (io, cb) {
   var file = this;
   this.open(function (err) {
     if (err) {
-      cb(err); file.close(); return;
+      cb(err); return;
     } else if (!channel.codeMirrorServer) {
       channel.codeMirrorServer = new EditorOTServer(
           file.content,
@@ -348,7 +334,7 @@ File.prototype.ot = function (io, cb) {
           });
         });
 
-        socket.on('disconnect', function () { file.close(); });
+        socket.on('disconnect', function () { });
 
         socket.on('operation', function () {
           file.nbops++;
@@ -475,7 +461,6 @@ File.prototype.files = function (cb) {
     }, function(err, files) {
       // We are finished now.  All files are processed!
       cb(err, files);   // Return from continuation.
-      folder.close();
     });
   });
 };
@@ -515,7 +500,6 @@ File.prototype.subfiles = function (cb, depth) {
     }, function(err) {
       // We are finished now.  All files are processed!
       cb(err, paths);   // Return from continuation.
-      folder.close();
     });
   });
 };

--- a/lib/irc.js
+++ b/lib/irc.js
@@ -39,7 +39,6 @@ exports.join = function (data, end) {
         file.open(function() {
           file.content += '\n[' + (new Date()+'').substring(16,24) + '] ';
           file.content += from + ': ' + message;
-          file.close();
         });
       });
     });


### PR DESCRIPTION
We don't need to `.close()` files anymore.
That prevents the current cases of leaked files.

@jankeromnes please review