### PR TITLE
Write sync

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -73,7 +73,8 @@ function loadMeta (vpath, cb) {
     fs.readFile(file, {encoding:'utf8'}, function (err, data) {
       if (err) { cb(err); return; }
       else if (data == '') {
-        // This goes around a sporadic bug in node.
+        // This should never happen, for more information see
+        // https://github.com/joyent/node/issues/7807
         data = fs.readFileSync(file, {encoding:'utf8'});
         if (data == '') {
           cb(new Error('Metadata Read Error'));
@@ -110,10 +111,9 @@ function dumpMeta (vpath, data, cb) {
         }
 
         // Then, we want to dump the metadata as JSON in that file.
-        fs.writeFile(file, JSON.stringify(data, null, 2), function (err) {
-          if (err) console.error('While dumping metadata:', err.stack);
-          cb(err);
-        });
+        var err = fs.writeFileSync(file, JSON.stringify(data, null, 2));
+        if (err) { console.error('While dumping metadata:', err.stack); }
+        cb(err);
       });
     } catch (e) {
       cb(e);
@@ -131,7 +131,7 @@ var primitives = {};  // Map from mime types to I/O primitives.
 
 primitives['dir'] = {
   read: function(vpath, cb) {fs.readdir(absolute(vpath), cb);},
-  mkfile: function(vpath, cb) {fs.writeFile(absolute(vpath), '', cb);},
+  mkfile: function(vpath, cb) {cb(fs.writeFileSync(absolute(vpath), ''));},
   mkdir: function(vpath, cb) {fs.mkdir(absolute(vpath), cb);},
   import: function(tmpfile, vpath, cb) {
     var source = temporary(tmpfile), destination = absolute(vpath);
@@ -160,8 +160,8 @@ primitives['dir'] = {
 primitives['binary'] = {
   read: function(vpath, cb) {fs.readFile(absolute(vpath), cb);},
   write: function(vpath, content, metadata, cb) {
-    fs.writeFile(absolute(vpath), content, cb);
     dumpMeta(vpath, metadata);
+    cb(fs.writeFileSync(absolute(vpath), content);
   },
   rm: function(vpath, cb) {
     metafile(normalize(vpath), function (err, fmeta) {
@@ -178,8 +178,8 @@ primitives['binary'] = {
 primitives['text'] = {
   read: function(vpath, cb) {fs.readFile(absolute(vpath), 'utf8', cb);},
   write: function(vpath, content, metadata, cb) {
-    fs.writeFile(absolute(vpath), content, 'utf8', cb);
     dumpMeta(vpath, metadata);
+    cb(fs.writeFileSync(absolute(vpath), content, 'utf8'));
   },
   rm: primitives['binary'].rm
 };

--- a/lib/test.js
+++ b/lib/test.js
@@ -85,11 +85,10 @@ tests.push(function testDriver(end) {
   }
 
   child.spawn('mkdir', ['-p', path.dirname(rpath)]).on('exit', function (code) {
-    fs.writeFile(rpath, "Whatever.", function onFileWritten(err) {
-      if (err)  console.error("Cannot create file", rpath);
-      // Add a sample meta file.
-      driver.dumpMeta(sample, {'hello':'world'}, doWithMetaFile);
-    });
+    var err = fs.writeFileSync(rpath, "Whatever.");
+    if (err) { console.error("Cannot create file", rpath); }
+    // Add a sample meta file.
+    driver.dumpMeta(sample, {'hello':'world'}, doWithMetaFile);
   });
 
 });


### PR DESCRIPTION
Reason: writeFile() truncates instantly, emptying the file for reading.
joyent/node#7807
